### PR TITLE
Update build_waitinginternal_app.md

### DIFF
--- a/phonegap_and_cordova/build_waitinginternal_app.md
+++ b/phonegap_and_cordova/build_waitinginternal_app.md
@@ -14,7 +14,7 @@ First step, create a new local project:
     $ cordova create waiting_app com.waiting.app.dev Waiting
     $ cd waiting_app
 
-- directory: `waiting`
+- directory: `waiting_app`
 - app id: `com.waiting.app.dev`
 - app name: `Waiting`
 


### PR DESCRIPTION
This change corrects a typo. In line 17 "- directory: `waiting` " changed to "- directory: `waiting_app` " in order to correspond to the command as is displayed in the first step to create a new local project

![waiting_app](https://cloud.githubusercontent.com/assets/1829649/6941287/f2422b96-d854-11e4-80e1-a0589b279839.png)
